### PR TITLE
Implement report completion

### DIFF
--- a/lib/checkr/report.rb
+++ b/lib/checkr/report.rb
@@ -65,6 +65,7 @@ module Checkr
     api_class_method :create, :post
 
     api_instance_method :save, :post, default_params: :changed_attributes
+    api_instance_method :complete, :post, ':path/complete'
 
     def self.path
       '/v1/reports'

--- a/test/checkr/report_test.rb
+++ b/test/checkr/report_test.rb
@@ -20,6 +20,13 @@ module Checkr
         assert(report.is_a?(Report))
         assert_equal(test_report[:id], report.id)
       end
+
+      should 'be completeable' do
+        id = "report_id"
+        @mock.expects(:get).once.with("#{@report_url}/#{id}", anything, anything).returns(test_response(test_report))
+        report = Report.retrieve(id)
+        assert(report.is_a?(Report))
+      end
     end
 
     context 'Report instance' do
@@ -41,6 +48,15 @@ module Checkr
         # This should update this instance with test_report since it was returned
         report.save
         assert_equal(test_report[:package], report.package)
+      end
+
+      should 'be completeable' do
+        report = Report.new(test_report)
+
+        @mock.expects(:post).once.with("#{@report_url}/#{test_report[:id]}/complete", anything, anything).returns(test_response(test_report))
+
+        report.complete
+        assert_equal(test_report[:status], "complete")
       end
     end
 

--- a/test/checkr/report_test.rb
+++ b/test/checkr/report_test.rb
@@ -20,13 +20,6 @@ module Checkr
         assert(report.is_a?(Report))
         assert_equal(test_report[:id], report.id)
       end
-
-      should 'be completeable' do
-        id = "report_id"
-        @mock.expects(:get).once.with("#{@report_url}/#{id}", anything, anything).returns(test_response(test_report))
-        report = Report.retrieve(id)
-        assert(report.is_a?(Report))
-      end
     end
 
     context 'Report instance' do
@@ -51,10 +44,8 @@ module Checkr
       end
 
       should 'be completeable' do
-        report = Report.new(test_report)
-
         @mock.expects(:post).once.with("#{@report_url}/#{test_report[:id]}/complete", anything, anything).returns(test_response(test_report))
-
+        report = Report.new(test_report)
         report.complete
         assert_equal(test_report[:status], "complete")
       end


### PR DESCRIPTION
@wyattades implementing a missing method in the Checkr API bindings:
See: https://docs.checkr.com/#operation/completeReport

Also raised PR to upstream:
https://github.com/checkr/checkr-ruby/pull/82